### PR TITLE
add controller-reviewers team

### DIFF
--- a/org.yaml
+++ b/org.yaml
@@ -36,7 +36,7 @@ orgs:
     - tjons
     teams:
       community-maintainers:
-        description: ""
+        description: Maintainers of the community repo
         maintainers:
         - ilrudie
         - jenshu
@@ -48,7 +48,7 @@ orgs:
         repos:
           community: maintain
       controller-maintainers:
-        description: ""
+        description: Maintainers of the kgateway repo
         maintainers:
         - jenshu
         - nfuden
@@ -71,6 +71,13 @@ orgs:
         privacy: closed
         repos:
           kgateway: maintain
+      controller-reviewers:
+        description: People who can approve PRs in the kgateway repo
+        members:
+        - timflannagan
+        privacy: closed
+        repos:
+          kgateway: write
       documentation-maintainers:
         description: ""
         privacy: closed


### PR DESCRIPTION
Add `controller-reviewers` team and add @timflannagan to it

refs:
- [Reviewer](https://github.com/kgateway-dev/community/blob/main/CONTRIBUTOR_LADDER.md#reviewer) on the contributor ladder
- GH [roles](https://docs.github.com/en/organizations/managing-user-access-to-your-organizations-repositories/managing-repository-roles/repository-roles-for-an-organization#permissions-for-each-role)