### PR TITLE
Nominate timflannagan as maintainer

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -28,6 +28,7 @@ Please keep the table sorted.
 | Seth Heidkamp | sheidkamp | Controller | Solo.io |
 | Shashank Ram | shashankram | Controller | Solo.io |
 | Steven Landow | stevenctl | Controller | Solo.io |
+| Tim Flannagan | timflannagan | Controller | Solo.io |
 | Tyler Schade | tjons | Controller | GEICO Insurance |
 | Will Rigby-Hall | williamgrh | Docs | Solo.io |
 | Yuval Kohavi | yuval-k | Controller, Proxy | Solo.io |

--- a/org.yaml
+++ b/org.yaml
@@ -67,6 +67,7 @@ orgs:
         - shashankram
         - sheidkamp
         - stevenctl
+        - timflannagan
         - tjons
         privacy: closed
         repos:


### PR DESCRIPTION
# Maintainer Nomination

Nominee's GitHub user ID: timflannagan

Summary of contributions: Tim has been an active contributor in kgateway over the last few months and has helped immensely in shaping the direction of the product:
- [49 PRs merged](https://github.com/kgateway-dev/kgateway/pulls?q=is%3Apr+is%3Amerged+author%3Atimflannagan)
- [over 40 PRs reviewed](https://github.com/kgateway-dev/kgateway/pulls?q=is%3Apr+reviewed-by%3Atimflannagan+-author%3Atimflannagan+)

Requirements:

- [x] The nominee has met all requirements to be a Maintainer, as outlined in the [contributor ladder](https://github.com/kgateway-dev/community/blob/main/CONTRIBUTOR_LADDER.md#maintainer)
- [x] In this PR, I have added the nominee's GitHub username to the appropriate maintainers list (`orgs.kgateway-dev.teams.<team>.members`) in [org.yaml](https://github.com/kgateway-dev/community/blob/main/org.yaml) (maintaining alphabetical order)
- [x] I have added the nominee to the list of active maintainers in [MAINTAINERS.md](https://github.com/kgateway-dev/community/blob/main/MAINTAINERS.md)
- [x] The nominee has added a comment to this PR testifying that they agree to the requirements of becoming a Maintainer, e.g. `I agree to all of the responsibilities and requirements of being a kgateway-dev maintainer`.