### PR TITLE
remove uneeded checkbox from maintainer template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/nominate_a_maintainer.md
+++ b/.github/PULL_REQUEST_TEMPLATE/nominate_a_maintainer.md
@@ -4,18 +4,17 @@
 This template should be used by a current Maintainer to nominate a current Organization Member to become a Maintainer in one or more repositories within the kgateway-dev organization.
 -->
 
-Nominee's GitHub user ID:
+**Nominee's GitHub user ID:** 
 
-Summary of contributions:
+**Summary of contributions:** 
 
 <!--
 This may include links to GitHub issues and/or GitHub queries showing significant contributions, and any other relevant information.
 -->
 
-Requirements:
+**Requirements:**
 
 - [ ] The nominee has met all requirements to be a Maintainer, as outlined in the [contributor ladder](https://github.com/kgateway-dev/community/blob/main/CONTRIBUTOR_LADDER.md#maintainer)
 - [ ] In this PR, I have added the nominee's GitHub username to the appropriate maintainers list (`orgs.kgateway-dev.teams.<team>.members`) in [org.yaml](https://github.com/kgateway-dev/community/blob/main/org.yaml) (maintaining alphabetical order)
-- [ ] If the nominee is not already a kgateway-dev Organization Member, I have also added the nominee's GitHub username to the `orgs.kgateway-dev.members` list in [org.yaml](https://github.com/kgateway-dev/community/blob/main/org.yaml) (maintaining alphabetical order)
 - [ ] I have added the nominee to the list of active maintainers in [MAINTAINERS.md](https://github.com/kgateway-dev/community/blob/main/MAINTAINERS.md)
 - [ ] The nominee has added a comment to this PR testifying that they agree to the requirements of becoming a Maintainer, e.g. `I agree to all of the responsibilities and requirements of being a kgateway-dev maintainer`.


### PR DESCRIPTION
Since you need to already be an org member to be nominated for maintainer, remove the unneeded checkbox