### PR TITLE
update docs maintainers

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -8,6 +8,7 @@ Please keep the table sorted.
 
 | Maintainer | GitHub ID | Specialization Areas | Company Affiliation |
 | ---- | ---- | ---- | ---- |
+| Art Berger | artberger | Docs | Solo.io |
 | Ashley Wang | ashleywang1 | Controller | Solo.io |
 | Craig Box | craigbox | Community, Docs | Solo.io |
 | Daneyon Hansen | danehans | Controller, Community | Solo.io |
@@ -18,10 +19,11 @@ Please keep the table sorted.
 | Jenny Shu | jenshu | Controller, Community | Solo.io |
 | Kevin Dorosh | kdorosh | Controller, Proxy | _unaffiliated_ |
 | Lawrence Gadban | lgadban | Controller | Solo.io |
-| Lin Sun | linsun | Community | Solo.io |
+| Lin Sun | linsun | Community, Docs | Solo.io |
 | Nadine Spies | Nadine2016 | Docs | Solo.io |
 | Nathan Fudenberg | nfuden | Controller, Proxy | Solo.io |
 | Nina Polshakova | npolshakova | Controller | Solo.io |
+| Rachael Graham | Rachael-Graham | Docs | Solo.io |
 | Sai Ekbote | saiskee | Controller, Proxy | HubSpot |
 | Sam Heilbron | sam-heilbron | Controller | Solo.io |
 | Scott Weiss | ilackarms | Controller | Solo.io |
@@ -29,6 +31,7 @@ Please keep the table sorted.
 | Shashank Ram | shashankram | Controller | Solo.io |
 | Steven Landow | stevenctl | Controller | Solo.io |
 | Tyler Schade | tjons | Controller | GEICO Insurance |
+| Wendie Cheung | wendeh | Docs | Solo.io |
 | Will Rigby-Hall | williamgrh | Docs | Solo.io |
 | Yuval Kohavi | yuval-k | Controller, Proxy | Solo.io |
 

--- a/org.yaml
+++ b/org.yaml
@@ -27,6 +27,7 @@ orgs:
     - lgadban
     - Nadine2016
     - npolshakova
+    - Rachael-Graham
     - saiskee
     - shashankram
     - sheidkamp
@@ -34,9 +35,10 @@ orgs:
     - stevenctl
     - timflannagan
     - tjons
+    - wendeh
     teams:
       community-maintainers:
-        description: ""
+        description: Maintainers of the community repo
         maintainers:
         - ilrudie
         - jenshu
@@ -48,7 +50,7 @@ orgs:
         repos:
           community: maintain
       controller-maintainers:
-        description: ""
+        description: Maintainers of the kgateway repo
         maintainers:
         - jenshu
         - nfuden
@@ -72,12 +74,19 @@ orgs:
         repos:
           kgateway: maintain
       documentation-maintainers:
-        description: ""
-        privacy: closed
+        description: Maintainers of the kgateway.dev repo
+        maintainers:
+        - linsun
+        - williamgrh
         members:
+        - artberger
         - craigbox
         - Nadine2016
-        - williamgrh
+        - Rachael-Graham
+        - wendeh
+        privacy: closed
+        repos:
+          kgateway.dev: maintain
       eligible-voters:
         description: ""
         maintainers:


### PR DESCRIPTION
Update the org.yaml and maintainers file to reflect the full list of docs maintainers (the yaml was not previously hooked up to the repo so they were out of sync)

Fixes https://github.com/kgateway-dev/community/issues/71