### PR TITLE
create a team for org members, grant triage permissions

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/apply_to_be_a_member.md
+++ b/.github/PULL_REQUEST_TEMPLATE/apply_to_be_a_member.md
@@ -14,5 +14,6 @@ Requirements:
 - [ ] I have enabled [2FA](https://docs.github.com/en/authentication/securing-your-account-with-two-factor-authentication-2fa) on my GitHub account
 - [ ] I have joined #kgateway channel on the [CNCF slack](https://slack.cncf.io)
 - [ ] In this PR, I have added my GitHub username to the `orgs.kgateway-dev.members` list in [org.yaml](https://github.com/kgateway-dev/community/blob/main/org.yaml) (maintaining alphabetical order)
+- [ ] In this PR, I have added my GitHub username to the `orgs.kgateway-dev.teams.org-members.members` list in [org.yaml](https://github.com/kgateway-dev/community/blob/main/org.yaml) (maintaining alphabetical order)
 
 Provide a link to at least one PR that you have successfully pushed to one of the project's repos:

--- a/CONTRIBUTOR_LADDER.md
+++ b/CONTRIBUTOR_LADDER.md
@@ -50,7 +50,7 @@ To apply to become a member of the kgateway-dev organization on GitHub, please o
 1. Use the [membership request template](.github/PULL_REQUEST_TEMPLATE/apply_to_be_a_member.md). This template is linked from the default template when you open a PR, or you can paste this URL in your browser `https://github.com/kgateway-dev/community/compare/main...<my-fork>:<my-branch>?quick_pull=1&title=Request%20org%20membership%20for%20<user>&labels=membership&template=apply_to_be_a_member.md`, replacing:
     - `<my-fork>:<my-branch>` with your fork/branch name, and
     - `<user>` with your GitHub username
-1. Add your GitHub username to the list of members (under `orgs.kgateway-dev.members`) in our [organization file](./org.yaml). Please add your name in the correct alphabetical order to maintain a tidy organization file.
+1. Add your GitHub username to the list of members (under `orgs.kgateway-dev.members` and `orgs.kgateway-dev.teams.org-members.members`) in our [organization file](./org.yaml). Please add your name in the correct alphabetical order to maintain a tidy organization file.
 
 ### Maintainer
 

--- a/org.yaml
+++ b/org.yaml
@@ -103,7 +103,7 @@ orgs:
         - kdorosh
         - tjons
         privacy: closed
-      members:
+      org-members:
         description: Members of the org; may triage
         maintainers:
         - gateway-bot

--- a/org.yaml
+++ b/org.yaml
@@ -103,4 +103,44 @@ orgs:
         - kdorosh
         - tjons
         privacy: closed
-
+      members:
+        description: Members of the org; may triage
+        maintainers:
+        - gateway-bot
+        - ilevine
+        - ilrudie
+        - jenshu
+        - linsun
+        - nfuden
+        - sam-heilbron
+        - williamgrh
+        - yuval-k
+        members:
+        - arianaw66
+        - artberger
+        - ashleywang1
+        - craigbox
+        - danehans
+        - davidjumani
+        - EItanya
+        - ilackarms
+        - jahvon
+        - jbohanon
+        - josh-pritchard
+        - kdorosh
+        - kevin-shelaga
+        - lgadban
+        - Nadine2016
+        - npolshakova
+        - Rachael-Graham
+        - saiskee
+        - shashankram
+        - sheidkamp
+        - Sodman
+        - stevenctl
+        - timflannagan
+        - tjons
+        - wendeh
+        privacy: closed
+        repos:
+          .default: triage


### PR DESCRIPTION
adds a new team for all members, members are granted triage permissions in all repositories

fix #77 