### PR TITLE
MAINTAINERS: update org for nfuden

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -21,7 +21,7 @@ Please keep the table sorted.
 | Lawrence Gadban | lgadban | Controller | Solo.io |
 | Lin Sun | linsun | Community, Docs | Solo.io |
 | Nadine Spies | Nadine2016 | Docs | Solo.io |
-| Nathan Fudenberg | nfuden | Controller, Proxy | Solo.io |
+| Nathan Fudenberg | nfuden | Controller, Proxy | Sandgarden |
 | Nina Polshakova | npolshakova | Controller | Solo.io |
 | Rachael Graham | Rachael-Graham | Docs | Solo.io |
 | Sai Ekbote | saiskee | Controller, Proxy | HubSpot |


### PR DESCRIPTION
As of May 12th this maintainer org change will be in effect.
As of April 25th the old maintainer org relationship is no longer in effect.