### PR TITLE
Nominate puertomontt as maintainer

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -23,6 +23,7 @@ Please keep the table sorted.
 | Nadine Spies | Nadine2016 | Docs | Solo.io |
 | Nathan Fudenberg | nfuden | Controller, Proxy | Sandgarden |
 | Nina Polshakova | npolshakova | Controller | Solo.io |
+| Omar Hammami | puertomontt | Controller | Solo.io |
 | Rachael Graham | Rachael-Graham | Docs | Solo.io |
 | Sai Ekbote | saiskee | Controller, Proxy | HubSpot |
 | Sam Heilbron | sam-heilbron | Controller | Solo.io |

--- a/org.yaml
+++ b/org.yaml
@@ -68,6 +68,7 @@ orgs:
         - jbohanon
         - nfuden
         - npolshakova
+        - puertomontt
         - saiskee
         - sam-heilbron
         - shashankram


### PR DESCRIPTION
# Maintainer Nomination

<!--
This template should be used by a current Maintainer to nominate a current Organization Member to become a Maintainer in one or more repositories within the kgateway-dev organization.
-->

**Nominee's GitHub user ID:** 

puertomontt

**Summary of contributions:** 

Omar has made extensive contributions to the project over the last few months, including ExtProc, TLSRoute and GRPCRoute support, retries/timeouts, overhauling logging, and adding BackendConfigPolicy.  List of merged PRs: https://github.com/kgateway-dev/kgateway/pulls?q=is%3Apr+author%3Apuertomontt+is%3Amerged

<!--
This may include links to GitHub issues and/or GitHub queries showing significant contributions, and any other relevant information.
-->

**Requirements:**

- [x] The nominee has met all requirements to be a Maintainer, as outlined in the [contributor ladder](https://github.com/kgateway-dev/community/blob/main/CONTRIBUTOR_LADDER.md#maintainer)
- [x] In this PR, I have added the nominee's GitHub username to the appropriate maintainers list (`orgs.kgateway-dev.teams.<team>.members`) in [org.yaml](https://github.com/kgateway-dev/community/blob/main/org.yaml) (maintaining alphabetical order)
- [x] I have added the nominee to the list of active maintainers in [MAINTAINERS.md](https://github.com/kgateway-dev/community/blob/main/MAINTAINERS.md)
- [x] The nominee has added a comment to this PR testifying that they agree to the requirements of becoming a Maintainer, e.g. `I agree to all of the responsibilities and requirements of being a kgateway-dev maintainer`.