### PR TITLE
Nominate christian-posta as maintainer

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -10,6 +10,7 @@ Please keep the table sorted.
 | ---- | ---- | ---- | ---- |
 | Art Berger | artberger | Docs | Solo.io |
 | Ashley Wang | ashleywang1 | Controller | Solo.io |
+| Christian Posta | christian-posta | Community, Docs | Solo.io |
 | Craig Box | craigbox | Community, Docs | Solo.io |
 | Daneyon Hansen | danehans | Controller, Community | Solo.io |
 | Eitan Yarmush | EItanya | Controller, Proxy | Solo.io |

--- a/org.yaml
+++ b/org.yaml
@@ -49,6 +49,7 @@ orgs:
         - jenshu
         - linsun
         members:
+        - christian-posta
         - craigbox
         - danehans
         privacy: closed
@@ -85,6 +86,7 @@ orgs:
         - linsun
         members:
         - artberger
+        - christian-posta
         - craigbox
         - Nadine2016
         - Rachael-Graham


### PR DESCRIPTION
# Maintainer Nomination

**Nominee's GitHub user ID:** 

christian-posta

**Summary of contributions:** 

Christian has been doing a lot of work to spread the word about kgateway, and has created a bunch of blogs and videos, e.g.
https://kgateway.dev/blog/llm-d-kgateway/
https://kgateway.dev/blog/deep-dive-inference-extensions/
https://kgateway.dev/blog/smarter-ai-reference-kubernetes-gateway-api/
https://www.youtube.com/watch?v=2wNXjCxrieo

**Requirements:**

- [x] The nominee has met all requirements to be a Maintainer, as outlined in the [contributor ladder](https://github.com/kgateway-dev/community/blob/main/CONTRIBUTOR_LADDER.md#maintainer)
- [x] In this PR, I have added the nominee's GitHub username to the appropriate maintainers list (`orgs.kgateway-dev.teams.<team>.members`) in [org.yaml](https://github.com/kgateway-dev/community/blob/main/org.yaml) (maintaining alphabetical order)
- [x] I have added the nominee to the list of active maintainers in [MAINTAINERS.md](https://github.com/kgateway-dev/community/blob/main/MAINTAINERS.md)
- [ ] The nominee has added a comment to this PR testifying that they agree to the requirements of becoming a Maintainer, e.g. `I agree to all of the responsibilities and requirements of being a kgateway-dev maintainer`.