### PR TITLE
Nominate davidjumani as maintainer

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -13,6 +13,7 @@ Please keep the table sorted.
 | Christian Posta | christian-posta | Community, Docs | Solo.io |
 | Craig Box | craigbox | Community, Docs | Solo.io |
 | Daneyon Hansen | danehans | Controller, Community | Solo.io |
+| David Jumani | davidjumani | Controller | Solo.io |
 | Eitan Yarmush | EItanya | Controller, Proxy | Solo.io |
 | Ian Rudie | ilrudie | Community | Solo.io |
 | Jacob Bohanon | jbohanon | Controller, Proxy  | Coinbase |

--- a/org.yaml
+++ b/org.yaml
@@ -65,6 +65,7 @@ orgs:
         members:
         - ashleywang1
         - danehans
+        - davidjumani
         - EItanya
         - ilackarms
         - jahvon


### PR DESCRIPTION
# Maintainer Nomination

**Nominee's GitHub user ID:** davidjumani

**Summary of contributions:**  David has been an active contributor to kgateway for a long time, most recently working on ListenerSet and OTel support. List of [merged PRs](https://github.com/kgateway-dev/kgateway/pulls?q=is%3Apr+is%3Amerged+author%3Adavidjumani+)

<!--
This may include links to GitHub issues and/or GitHub queries showing significant contributions, and any other relevant information.
-->

**Requirements:**

- [x] The nominee has met all requirements to be a Maintainer, as outlined in the [contributor ladder](https://github.com/kgateway-dev/community/blob/main/CONTRIBUTOR_LADDER.md#maintainer)
- [x] In this PR, I have added the nominee's GitHub username to the appropriate maintainers list (`orgs.kgateway-dev.teams.<team>.members`) in [org.yaml](https://github.com/kgateway-dev/community/blob/main/org.yaml) (maintaining alphabetical order)
- [x] I have added the nominee to the list of active maintainers in [MAINTAINERS.md](https://github.com/kgateway-dev/community/blob/main/MAINTAINERS.md)
- [ ] The nominee has added a comment to this PR testifying that they agree to the requirements of becoming a Maintainer, e.g. `I agree to all of the responsibilities and requirements of being a kgateway-dev maintainer`.