### PR TITLE
Nominate Sodman as maintainer

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -31,6 +31,7 @@ Please keep the table sorted.
 | Sam Heilbron | sam-heilbron | Controller | Solo.io |
 | Scott Weiss | ilackarms | Controller | Solo.io |
 | Seth Heidkamp | sheidkamp | Controller | Solo.io |
+| Shane O'Donnell | Sodman | Controller | Solo.io |
 | Shashank Ram | shashankram | Controller | Solo.io |
 | Steven Landow | stevenctl | Controller | Solo.io |
 | Tim Flannagan | timflannagan | Controller | Solo.io |

--- a/org.yaml
+++ b/org.yaml
@@ -78,6 +78,7 @@ orgs:
         - sam-heilbron
         - shashankram
         - sheidkamp
+        - Sodman
         - stevenctl
         - timflannagan
         - tjons


### PR DESCRIPTION
# Maintainer Nomination

**Nominee's GitHub user ID:**  Sodman

**Summary of contributions:** 

Shane has been a long-time contributor to the kgateway project.
List of [merged PRs](https://github.com/kgateway-dev/kgateway/pulls?q=is%3Apr+is%3Amerged+author%3Asodman)
List of [reviewed PRs](https://github.com/kgateway-dev/kgateway/pulls?q=is%3Apr+reviewed-by%3Asodman+)

**Requirements:**

- [x] The nominee has met all requirements to be a Maintainer, as outlined in the [contributor ladder](https://github.com/kgateway-dev/community/blob/main/CONTRIBUTOR_LADDER.md#maintainer)
- [x] In this PR, I have added the nominee's GitHub username to the appropriate maintainers list (`orgs.kgateway-dev.teams.<team>.members`) in [org.yaml](https://github.com/kgateway-dev/community/blob/main/org.yaml) (maintaining alphabetical order)
- [x] I have added the nominee to the list of active maintainers in [MAINTAINERS.md](https://github.com/kgateway-dev/community/blob/main/MAINTAINERS.md)
- [ ] The nominee has added a comment to this PR testifying that they agree to the requirements of becoming a Maintainer, e.g. `I agree to all of the responsibilities and requirements of being a kgateway-dev maintainer`.