### PR TITLE
Contributing guidelines: stale assignments

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,8 +55,7 @@ We welcome community contributions and encourage members to work on issues. To m
 
 ### Assignment Process
 - **Organization members**: Can self-assign issues using the GitHub assignee dropdown
-- **External contributors**: Should comment on the issue expressing interest in working on it. A maintainer will then assign the issue to you
-- **Note**: We previously attempted to support the `/assign` command ([kgateway#11674](https://github.com/kgateway-dev/kgateway/issues/11674)) but closed it as it needed more consideration
+- **External contributors**: Should comment on the issue expressing interest in working on it. A maintainer will then assign the issue to you.
 
 ### Stale Assignment Policy
 - **Timeframe**: If an assignee hasn't made any visible progress (comments, commits, or draft PRs) within **3 weeks** of assignment, the issue may be considered stale

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,6 +8,10 @@ Here are some of the ways you can contribute:
   - [Report Security Vulnerabilities](#report-security-vulnerabilities)
   - [File issues](#file-issues)
   - [Find something to work on](#find-something-to-work-on)
+- [Community Assignments](#community-assignments)
+  - [Assignment Process](#assignment-process)
+  - [Stale Assignment Policy](#stale-assignment-policy)
+  - [Best Practices for Assignees](#best-practices-for-assignees)
 - [Contributing code](#contributing-code)
   - [Small changes (bug fixes)](#small-changes-bug-fixes)
   - [Large changes (features, refactors)](#large-changes-features-refactors)
@@ -50,7 +54,7 @@ Additionally, the project has a [milestone](https://github.com/kgateway-dev/kgat
 
 Flaky tests are a common source of issues and a good place to start contributing to the project. You can find these issues by filtering with the `Type: CI Test Flake` label. If you see a test that is failing regularly, you can leave a comment asking if someone is working on it.
 
-### Community Assignments
+## Community Assignments
 We welcome community contributions and encourage members to work on issues. To maintain an active and healthy development environment, we have the following policies:
 
 ### Assignment Process
@@ -58,7 +62,7 @@ We welcome community contributions and encourage members to work on issues. To m
 - **External contributors**: Should comment on the issue expressing interest in working on it. A maintainer will then assign the issue to you.
 
 ### Stale Assignment Policy
-- **Timeframe**: If an assignee hasn't made any visible progress (comments, commits, or draft PRs) within **30 days** of assignment, the issue may be considered stale
+- **Timeframe**: If an assignee hasn't made any visible progress (comments, commits, or draft PRs) within **30 days** of assignment, the issue assignment may be considered stale
 - **Communication**: We'll reach out to check on progress and offer assistance before unassigning
 - **Unassignment**: After **5 additional days** without response or progress, issues will be unassigned and made available for other contributors
 - **Re-assignment**: Previous assignees are welcome to request re-assignment if they become available to work on the issue again

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,7 +51,12 @@ Additionally, the project has a [milestone](https://github.com/kgateway-dev/kgat
 Flaky tests are a common source of issues and a good place to start contributing to the project. You can find these issues by filtering with the `Type: CI Test Flake` label. If you see a test that is failing regularly, you can leave a comment asking if someone is working on it.
 
 ### Community Assignments
-We welcome community contributions and encourage members to self-assign issues they'd like to work on. To maintain an active and healthy development environment, we have the following policies:
+We welcome community contributions and encourage members to work on issues. To maintain an active and healthy development environment, we have the following policies:
+
+### Assignment Process
+- **Organization members**: Can self-assign issues using the GitHub assignee dropdown
+- **External contributors**: Should comment on the issue expressing interest in working on it. A maintainer will then assign the issue to you
+- **Note**: We previously attempted to support the `/assign` command ([kgateway#11674](https://github.com/kgateway-dev/kgateway/issues/11674)) but closed it as it needed more consideration
 
 ### Stale Assignment Policy
 - **Timeframe**: If an assignee hasn't made any visible progress (comments, commits, or draft PRs) within **3 weeks** of assignment, the issue may be considered stale

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,6 +50,21 @@ Additionally, the project has a [milestone](https://github.com/kgateway-dev/kgat
 
 Flaky tests are a common source of issues and a good place to start contributing to the project. You can find these issues by filtering with the `Type: CI Test Flake` label. If you see a test that is failing regularly, you can leave a comment asking if someone is working on it.
 
+### Community Assignments
+We welcome community contributions and encourage members to self-assign issues they'd like to work on. To maintain an active and healthy development environment, we have the following policies:
+
+### Stale Assignment Policy
+- **Timeframe**: If an assignee hasn't made any visible progress (comments, commits, or draft PRs) within **3 weeks** of assignment, the issue may be considered stale
+- **Communication**: We'll reach out to check on progress and offer assistance before unassigning
+- **Unassignment**: After **1 additional week** (4 weeks total) without response or progress, issues will be unassigned and made available for other contributors
+- **Re-assignment**: Previous assignees are welcome to request re-assignment if they become available to work on the issue again
+
+### Best Practices for Assignees
+- Comment on the issue with your approach or ask questions if you need clarification
+- Provide regular updates (even brief ones) if work is taking longer than expected
+- Create draft PRs early to show progress and get feedback
+- Don't hesitate to ask for help in the issue comments or community channels like the #kgateway CNCF slack channel
+
 ## Contributing code
 
 Contributing features to kgateway is a great way to get involved with the project. We welcome contributions of all sizes, from small bug fixes to large new features. Kgateway uses a "fork and pull request" approach. This means that as a contributor, you create your own personal fork of a code repository in GitHub and push your contributions to a branch in your own fork first. When you are ready to contribute, open a pull request (PR) against the project's repository. For more details, see the [GitHub docs about working with forks](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,7 +60,7 @@ We welcome community contributions and encourage members to work on issues. To m
 ### Stale Assignment Policy
 - **Timeframe**: If an assignee hasn't made any visible progress (comments, commits, or draft PRs) within **30 days** of assignment, the issue may be considered stale
 - **Communication**: We'll reach out to check on progress and offer assistance before unassigning
-- **Unassignment**: After **1 additional week** without response or progress, issues will be unassigned and made available for other contributors
+- **Unassignment**: After **5 additional days** without response or progress, issues will be unassigned and made available for other contributors
 - **Re-assignment**: Previous assignees are welcome to request re-assignment if they become available to work on the issue again
 
 ### Best Practices for Assignees

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -58,9 +58,9 @@ We welcome community contributions and encourage members to work on issues. To m
 - **External contributors**: Should comment on the issue expressing interest in working on it. A maintainer will then assign the issue to you.
 
 ### Stale Assignment Policy
-- **Timeframe**: If an assignee hasn't made any visible progress (comments, commits, or draft PRs) within **3 weeks** of assignment, the issue may be considered stale
+- **Timeframe**: If an assignee hasn't made any visible progress (comments, commits, or draft PRs) within **30 days** of assignment, the issue may be considered stale
 - **Communication**: We'll reach out to check on progress and offer assistance before unassigning
-- **Unassignment**: After **1 additional week** (4 weeks total) without response or progress, issues will be unassigned and made available for other contributors
+- **Unassignment**: After **1 additional week** without response or progress, issues will be unassigned and made available for other contributors
 - **Re-assignment**: Previous assignees are welcome to request re-assignment if they become available to work on the issue again
 
 ### Best Practices for Assignees


### PR DESCRIPTION
This PR addresses stale assignment guidelines in the contributing documentation.

I would like to bring this up at the next community meeting.