### PR TITLE
Request org membership for NomadXD

### DIFF
--- a/org.yaml
+++ b/org.yaml
@@ -41,6 +41,7 @@ orgs:
     - markuskobler
     - MayorFaj
     - Nadine2016
+    - NomadXD
     - nfuden
     - petrmc
     - puertomontt
@@ -193,6 +194,7 @@ orgs:
         - markuskobler
         - MayorFaj
         - Nadine2016
+        - NomadXD
         - nfuden
         - petrmc
         - puertomontt


### PR DESCRIPTION
# Kgateway-dev Org Membership Request

<!--
If you would like to become a member of the organization on GitHub, please submit a PR to the community repo using this template. Give us a few days to review and you should receive an invitation to join.
-->

GitHub user ID: NomadXD

Company affiliation: WSO2

Requirements:

- [x] I have reviewed the project [contributing guide](https://github.com/kgateway-dev/community/blob/main/CONTRIBUTING.md)
- [x] I have enabled [2FA](https://docs.github.com/en/authentication/securing-your-account-with-two-factor-authentication-2fa) on my GitHub account
- [x] I have joined both the [`#kgateway`](https://cloud-native.slack.com/archives/C080D3PJMS4) and [`#kgateway-contributors`](https://cloud-native.slack.com/archives/C09LVSV2TV3) channels on the [CNCF slack](https://slack.cncf.io)
- [x] In this PR, I have added my GitHub username to the `orgs.kgateway-dev.members` list in [org.yaml](https://github.com/kgateway-dev/community/blob/main/org.yaml) (maintaining alphabetical order)
- [x] In this PR, I have added my GitHub username to the `orgs.kgateway-dev.teams.org-members.members` list in [org.yaml](https://github.com/kgateway-dev/community/blob/main/org.yaml) (maintaining alphabetical order)

Provide a link to at least five PRs that you have successfully pushed to one of the project's repos:
[feat: support TLS termination for TLSRoute on TLS listener](https://github.com/kgateway-dev/kgateway/pull/13548)
[fix: gate Istio resource watching behind EnableIstioIntegration setting](https://github.com/kgateway-dev/kgateway/pull/13611)
[feat: add app.kubernetes.io/component labels to controller and proxy deployments](https://github.com/kgateway-dev/kgateway/pull/13619)
[feat: add per-route tracing overrides via TrafficPolicy](https://github.com/kgateway-dev/kgateway/pull/13648)
[fix: restore negative CORS e2e assertions with relaxed preflight status handling](https://github.com/kgateway-dev/kgateway/pull/13700)
