### PR TITLE
Nominate kristin-kronstain-brown as documentation-maintainer

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -23,6 +23,7 @@ Please keep the table sorted.
 | Jenny Shu | jenshu | Controller, Community | Solo.io |
 | John Howard | howardjohn | Controller | Solo.io |
 | Kevin Dorosh | kdorosh | Controller, Proxy | _unaffiliated_ |
+| Kristin Kronstain Brown | kristin-kronstain-brown | Docs | Solo.io |
 | Lawrence Gadban | lgadban | Controller | Solo.io |
 | Lin Sun | linsun | Community, Docs | Solo.io |
 | Nadine Spies | Nadine2016 | Docs | Solo.io |

--- a/org.yaml
+++ b/org.yaml
@@ -114,6 +114,7 @@ orgs:
         - artberger
         - christian-posta
         - craigbox
+        - kristin-kronstain-brown
         - Nadine2016
         - Rachael-Graham
         - wendeh


### PR DESCRIPTION
# Maintainer Nomination

**Nominee's GitHub user ID:** kristin-kronstain-brown

**Summary of contributions:** 
Reviewed: 25 (merged)
https://github.com/kgateway-dev/kgateway.dev/pulls?q=is%3Apr+is%3Aopen+reviewed-by%3A%40kristin-kronstain-brown

Created: 33 (merged)
https://github.com/kgateway-dev/kgateway.dev/pulls?q=is%3Apr+author%3Akristin-kronstain-brown+is%3Aclosed

**Requirements:**

- [x] The nominee has met all requirements to be a Maintainer, as outlined in the [contributor ladder](https://github.com/kgateway-dev/community/blob/main/CONTRIBUTOR_LADDER.md#maintainer)
- [x] In this PR, I have added the nominee's GitHub username to the appropriate maintainers list (`orgs.kgateway-dev.teams.<team>.members`) in [org.yaml](https://github.com/kgateway-dev/community/blob/main/org.yaml) (maintaining alphabetical order)
- [x] I have added the nominee to the list of active maintainers in [MAINTAINERS.md](https://github.com/kgateway-dev/community/blob/main/MAINTAINERS.md)
- [x] The nominee has added a comment to this PR testifying that they agree to the requirements of becoming a Maintainer, e.g. `I agree to all of the responsibilities and requirements of being a kgateway-dev maintainer`.